### PR TITLE
Fix test by updating inherited component API

### DIFF
--- a/src/Popover.js
+++ b/src/Popover.js
@@ -18,8 +18,8 @@ class Popover extends TooltipBase {
 	 * @param {Element} prevAlignElement
 	 * @override
 	 */
-	syncAlignElement(alignElement) {
-		super.syncAlignElement(alignElement);
+	syncCurrentAlignElement(alignElement) {
+		super.syncCurrentAlignElement(alignElement);
 
 		if (alignElement) {
 			var dataContent = alignElement.getAttribute('data-content');

--- a/test/Popover.js
+++ b/test/Popover.js
@@ -90,7 +90,7 @@ describe('Popover', function() {
 		dom.triggerEvent(trigger, 'click');
 		setTimeout(function() {
 			assert.ok(popover.visible);
-			assert.strictEqual(trigger, popover.alignElement);
+			assert.strictEqual(trigger, popover.currentAlignElement);
 			dom.exitDocument(trigger);
 			done();
 		}, 25);


### PR DESCRIPTION
This fixes two tests found in the [`metal-components` travis build](https://travis-ci.org/metal/metal-components):

```
Edge 13.10586.0 (Windows 10 0.0.0) Popover should open and close on click events by default FAILED
	Error: AssertionError: expected <div id="trigger">trigger</div> to equal null (/home/travis/build/metal/metal-components/node_modules/chai/chai.js:206)
Edge 13.10586.0 (Windows 10 0.0.0) Popover should get content from the align element's data-content FAILED
	Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.
```

